### PR TITLE
chore: use nginx for service static frontend

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
 * {
     reverse_proxy /api/* http://b4w-backend:8002
-    reverse_proxy /* http://b4w-frontend:3002
+    reverse_proxy /* http://b4w-frontend
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Python base image
-FROM python:3.10-slim
+FROM python:3.10-alpine
 
 # Set working directory
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,12 @@
 # Use a Node.js base image
-FROM node:18-alpine
+FROM node:18-alpine as builder
 
 # Set working directory
 WORKDIR /app
 
 # Copy package files and install dependencies
 COPY package.json package-lock.json ./
-RUN npm install
+RUN npm ci
 
 # Copy the rest of the frontend code
 COPY . .
@@ -14,8 +14,17 @@ COPY . .
 # Build the frontend
 RUN npm run build
 
-# Expose the frontend port
-EXPOSE 3002
+FROM nginx:alpine
 
-# Serve the frontend using a lightweight HTTP server
-CMD ["npx", "serve", "-s", "build", "-l", "3002"]
+# Remove default nginx static content
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy built static files
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Copy custom nginx config (optional but recommended)
+# COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
try to make the docker images smaller

for the backend, just switch to the alpine based image: 53.55MB->27.18MB a 50% reduction! 

![image](https://github.com/user-attachments/assets/9fe5c3a9-2ad5-43bc-83e7-63be45e03792)

For the frontend, switch to building the assets and then serving them using an nginx container: 202.01MB->41.57MB a 60% reduction!

![image](https://github.com/user-attachments/assets/417fe720-857d-44b7-b0bd-9980d2c28321)

Also the CPU difference was relitivly the same for each image, but the memory footprint of the frontend went from 96MB to 2.84MB!!

![image](https://github.com/user-attachments/assets/ac7143db-5801-48b7-a839-4326c671e271)
