### PR TITLE
feat: add metrics to gather with prometheus

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi import Depends
 from app.auth import get_current_user
 from app.auth import create_access_token
 from app.models import UserOnly, UpdateUserInfo, CampaignAndUserOnly
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.scheduler import start_scheduler
 from database import init_db
@@ -20,10 +21,13 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type"]
 )
 
+instrumentator = Instrumentator().instrument(app)
+
 @app.on_event("startup")
 async def startup_event():
     start_scheduler()
     init_db()
+    instrumentator.expose(app, include_in_schema=True, should_gzip=False)
 
 @app.post("/api/word/reveal")
 def reveal_word(data: models.CampaignOnly):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-jose
 pydantic
 bcrypt
 apscheduler
+prometheus-fastapi-instrumentator


### PR DESCRIPTION
add this instrumentator i found on github

will be able to get metrics by doing `ip:8002/metrics`

because you only pass public traffic to the container when it starts with `/api` end users cant see this data, but I can scrap it with my prometheus server and create some visuals in grafana.

we should be able to create some alerts when we see high numbers of 400/500 errors, or even just watch general user activity (when guesses happen, when new campaigns are created, ect)