### PR TITLE
Fix/invalid word

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -335,7 +335,7 @@ def validate_guess(word: str, user_id: int, campaign_id: int):
     }
 
     if word.lower() not in VALID_WORDS:
-        raise HTTPException(status_code=400, detail="Invalid word")
+        raise HTTPException(status_code=204, detail="Invalid word")
 
     secret = get_daily_word(campaign_id)
     guess = word.lower()

--- a/frontend/src/pages/GameScreen.jsx
+++ b/frontend/src/pages/GameScreen.jsx
@@ -331,6 +331,12 @@ export default function GameScreen() {
         },
         body: JSON.stringify({ word: guess, campaign_id }),
       });
+
+      if (res.status === 204) {
+        setErrorMsg("❌ Not a valid word");
+        setTimeout(() => setErrorMsg(null), 3000); // clears after 3 seconds
+        return;
+      }
       
       if (!res.ok) {
         const error = await res.json();


### PR DESCRIPTION
after i started watching metrics, i noticed a lot of errors

i saw then that it was from the `/guess` endpoint, which returns 400 if a user guesses a word not in the approved list

i am changing the response code for invalid words to be `204` so that its stiil a "successful" api call, but the front end will still see this as an invalid word and throw the expected error.